### PR TITLE
세벌식 모아치기 2015 결합 규칙 수정 및 시프트 위치 추가

### DIFF
--- a/js/keyboard_table_combination.js
+++ b/js/keyboard_table_combination.js
@@ -828,7 +828,7 @@ var K3_3shin_2015 = [
             array_default = K3_3moa_2014;
             break;
         case /3moa-2015/.test(type) :
-            array_default = K3_3moa_2014;
+            array_default = K3_3moa_2015;
             break;
         case /3shin-2015-shift/.test(type) :
             array_specific = K3_3shin_2015;

--- a/js/ohi.js
+++ b/js/ohi.js
@@ -1999,6 +1999,9 @@ if (KE_status == 'ko') {
             node_key = $("#key_apostrophe .up_key .han_key");
             node_key.html(tab_moa_gawit_shift);
             node_key.addClass("tag10");
+            node_key = $("#key_v .up_key .han_key");
+            node_key.html(tab_moa_gawit_shift);
+            node_key.addClass("tag10");
             node_key = $("#key_semicolon .up_key .han_key");
             node_key.html(tab_moa_ggeut_shift);
             node_key.addClass("tag10");


### PR DESCRIPTION
세벌식 모아치기 2015 자판의 결합 규칙 수정입니다.
세벌식 모아치기 2014 자판의 결합 규칙으로 나타나는 것을 수정하였습니다.
저번에 함께 수정했어야 했는데, 제가 이제야 이 상황을 확인하였습니다...

또한, 글쇠 위치만 바꾸면 되는 줄 알았는데, 저번에 바꿔 주신 커밋을 보니
그 외에도 바뀐 'ㅗ'의 위치를 설정하는 것과, 시프트 표시 위치도 변경이 필요했었군요...
그 때 제대로 확인했어야 했는데, 너무 늦게 알게 되어 번거롭게 해 드려서 죄송합니다...

수정하는 김에 V 키에 시프트 표시도 추가하였습니다...
